### PR TITLE
Updated pull docker image with fewer platforms

### DIFF
--- a/.github/workflows/pull_image.yaml
+++ b/.github/workflows/pull_image.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
       with:
-        platforms: linux/amd64,linux/arm64,linux/riscv64,linux/mips64
+        platforms: linux/amd64,linux/arm64
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:
@@ -31,5 +31,5 @@ jobs:
         context: .
         file: ./Dockerfile
         push: true
-        platforms: linux/amd64,linux/arm64,linux/riscv64,linux/mips64
+        platforms: linux/amd64,linux/arm64
         tags: ghcr.io/owosrl/lanotte24ore:latest


### PR DESCRIPTION
Python 3.10 Alpine doesn't support RISC V